### PR TITLE
add typescript declaration file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,116 @@
+declare module 'cleverpush-react-native' {
+	export default class CleverPush {
+		static init(channelId: string, options?: InitOptions): void;
+
+		static isSubscribed(callback: (error, isSubscribed: boolean) => void): void;
+		static areNotificationsEnabled(callback: (error, notificationsEnabled: boolean) => void): void;
+		static subscribe(): void;
+		static unsubscribe(): void;
+		static showTopicsDialog(): void;
+
+		static addEventListener(
+			type: EventType,
+			handler: (result: { notification: Notification; subscription: Subscription }) => void
+		): void;
+		static removeEventListener(
+			type: EventType,
+			handler: (result: { notification: Notification; subscription: Subscription }) => void
+		): void;
+		static clearListeners(): void;
+
+		static getAvailableTags(callback: (error, channelTags: Tag[]) => void): void;
+		static getAvailableAttributes(callback: (error, channelTags: Attribute[]) => void): void;
+		static getSubscriptionTags(callback: (error, tagIds: string[]) => void): void;
+		static getSubscriptionAttributes(callback: (error, attributes: Record<string, string>) => void): void;
+		static addSubscriptionTag(tagId: string): void;
+		static removeSubscriptionTag(tagId: string): void;
+		static setSubscriptionAttribute(attributeId: string, value: string): void;
+		static hasSubscriptionTag(tagId: string, callback: (error, hasTag: boolean) => void): void;
+		static getSubscriptionAttribute(attributeId: string, callback: (error, attributeValue: string) => void): void;
+		static setSubscriptionLanguage(value: string): void;
+		static setSubscriptionCountry(value: string): void;
+
+		static trackPageView(url: string, params: Record<string, any>): void;
+
+		static getNotifications(callback: (error, notifications: Notification[]) => void): void;
+	}
+
+	export type InitOptions = {
+		autoRegister?: boolean;
+	};
+
+	type EventType = 'received' | 'opened' | 'subscribed' | 'appBannerOpened';
+
+	export interface Tag {
+		id: string;
+		name: string;
+	}
+
+	export interface Attribute {
+		id: string;
+		name: string;
+	}
+
+	export interface Subscription {
+		id: string;
+	}
+
+	export interface Notification {
+		id: string;
+		tag: string;
+		title: string;
+		text: string;
+		url: string;
+		iconUrl: string;
+		mediaUrl: string;
+		actions?: NotificationAction[];
+		customData: Record<string, any>;
+		chatNotification: boolean;
+		carouselEnabled: boolean;
+		carouselItems?: NotificationCarouselItem[];
+		category?: NotificationCategory;
+		soundFilename?: string;
+		silent: boolean;
+		createdAt: string;
+		appBanner: string;
+		inboxAppBanner?: string;
+		voucherCode?: string;
+		autoHandleDeepLink?: boolean;
+	}
+
+	export interface NotificationAction {
+		title: string;
+		url: string;
+		icon: string;
+		phone: string;
+		id: string;
+		type: string;
+	}
+
+	export interface NotificationCategory {
+		id: string;
+		group: NotificationCategoryGroup;
+		name: string;
+		description: string;
+		soundEnabled: boolean;
+		soundFilename: string;
+		vibrationEnabled: boolean;
+		vibrationPattern: string;
+		ledColorEnabled: boolean;
+		ledColor: string;
+		lockScreen: string;
+		importance: string;
+		badgeDisabled: boolean;
+		backgroundColor: string;
+		foregroundColor: string;
+	}
+
+	export interface NotificationCategoryGroup {
+		id: string;
+		name: string;
+	}
+
+	export interface NotificationCarouselItem {
+		mediaUrl: string;
+	}
+}


### PR DESCRIPTION
Because I noticed that other users also want to use this SDK within a typescript project and miss the typings (https://github.com/cleverpush/cleverpush-react-native-sdk/issues/12), I want to share my declaration file. 

Some Typings are not perfect (like `error`) and I am not fully sure which fields within the notifications are really optional fields - those typings are based on the Java classes and some test push notifications.
