### PR TITLE
hotfix/CP-8943-react-native-sdk-native-event-emitter-warnings

### DIFF
--- a/android/src/main/java/com/cleverpush/reactnative/RNCleverPush.java
+++ b/android/src/main/java/com/cleverpush/reactnative/RNCleverPush.java
@@ -575,6 +575,19 @@ public class RNCleverPush extends ReactContextBaseJavaModule implements Lifecycl
         this.showNotificationsInForeground = show;
     }
 
+    /**
+     * Added for NativeEventEmitter
+     */
+    @ReactMethod
+    public void addListener(String eventName) {
+        // Keep: Required for RN built in Event Emitter Calls.
+    }
+
+    @ReactMethod
+    public void removeListeners(int count) {
+        // Keep: Required for RN built in Event Emitter Calls.
+    }
+
     private void notifySubscribed(String subscriptionId) {
         try {
             WritableMap result = new WritableNativeMap();


### PR DESCRIPTION
Added `addListener` and `removeListeners` in Android.

These warnings only appear for Android, so did not add ReactMethod in iOS.