### PR TITLE
hotfix/cp-9366-react-native-sdk-getavailabletopics-only-returns-null

### DIFF
--- a/ios/RCTCleverPush/RCTCleverPushEventEmitter.m
+++ b/ios/RCTCleverPush/RCTCleverPushEventEmitter.m
@@ -90,17 +90,23 @@ RCT_EXPORT_METHOD(getAvailableTopics:(RCTResponseSenderBlock)callback) {
     for (CPChannelTopic *topic in channelTopics) {
         NSMutableDictionary *topicDict = [NSMutableDictionary dictionary];
         
-        if (topic.id != nil && ![topic.id isKindOfClass:[NSNull class]] && ![topic.id isEqualToString:@""]) {
-            [topicDict setObject:topic.id forKey:@"id"];
-        } else {
-            [topicDict setObject:@"" forKey:@"id"];
+        NSString *topicId = @"";
+        if (topic.id != nil && ![topic.id isKindOfClass:[NSNull class]] && [topic.id isKindOfClass:[NSString class]]) {
+            NSString *idString = (NSString *)topic.id;
+            if (![idString isEqualToString:@""]) {
+                topicId = idString;
+            }
         }
+        [topicDict setObject:topicId forKey:@"id"];
         
-        if (topic.name != nil && ![topic.name isKindOfClass:[NSNull class]] && ![topic.name isEqualToString:@""]) {
-            [topicDict setObject:topic.name forKey:@"name"];
-        } else {
-            [topicDict setObject:@"" forKey:@"name"];
+        NSString *topicName = @"";
+        if (topic.name != nil && ![topic.name isKindOfClass:[NSNull class]] && [topic.name isKindOfClass:[NSString class]]) {
+            NSString *nameString = (NSString *)topic.name;
+            if (![nameString isEqualToString:@""]) {
+                topicName = nameString;
+            }
         }
+        [topicDict setObject:topicName forKey:@"name"];
         
         [topicsArray addObject:topicDict];
     }

--- a/ios/RCTCleverPush/RCTCleverPushEventEmitter.m
+++ b/ios/RCTCleverPush/RCTCleverPushEventEmitter.m
@@ -84,8 +84,17 @@ RCT_EXPORT_METHOD(getAvailableTags:(RCTResponseSenderBlock)callback) {
 }
 
 RCT_EXPORT_METHOD(getAvailableTopics:(RCTResponseSenderBlock)callback) {
-    NSArray* channelTopics = [CleverPush getAvailableTopics];
-    callback(@[[NSNull null], channelTopics]);
+    NSArray *channelTopics = [CleverPush getAvailableTopics];
+    NSMutableArray *topicsArray = [NSMutableArray new];
+    
+    for (CPChannelTopic *topic in channelTopics) {
+        NSMutableDictionary *topicDict = [NSMutableDictionary new];
+        [topicDict setObject:topic.id forKey:@"id"];
+        [topicDict setObject:topic.name forKey:@"name"];
+        [topicsArray addObject:topicDict];
+    }
+    
+    callback(@[[NSNull null], topicsArray]);
 }
 
 RCT_EXPORT_METHOD(getAvailableAttributes:(RCTResponseSenderBlock)callback) {

--- a/ios/RCTCleverPush/RCTCleverPushEventEmitter.m
+++ b/ios/RCTCleverPush/RCTCleverPushEventEmitter.m
@@ -88,9 +88,20 @@ RCT_EXPORT_METHOD(getAvailableTopics:(RCTResponseSenderBlock)callback) {
     NSMutableArray *topicsArray = [NSMutableArray new];
     
     for (CPChannelTopic *topic in channelTopics) {
-        NSMutableDictionary *topicDict = [NSMutableDictionary new];
-        [topicDict setObject:topic.id forKey:@"id"];
-        [topicDict setObject:topic.name forKey:@"name"];
+        NSMutableDictionary *topicDict = [NSMutableDictionary dictionary];
+        
+        if (topic.id != nil && ![topic.id isKindOfClass:[NSNull class]] && ![topic.id isEqualToString:@""]) {
+            [topicDict setObject:topic.id forKey:@"id"];
+        } else {
+            [topicDict setObject:@"" forKey:@"id"];
+        }
+        
+        if (topic.name != nil && ![topic.name isKindOfClass:[NSNull class]] && ![topic.name isEqualToString:@""]) {
+            [topicDict setObject:topic.name forKey:@"name"];
+        } else {
+            [topicDict setObject:@"" forKey:@"name"];
+        }
+        
         [topicsArray addObject:topicDict];
     }
     


### PR DESCRIPTION
resolved the issue of `getAvailableTopics` function returning a null value.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the getAvailableTopics function in the React Native SDK to return a list of topic objects instead of null. Now, each topic includes its id and name.

<!-- End of auto-generated description by cubic. -->

