### PR TITLE
hotfix/cp-9475-react-native-sdk-subscribed-not-called

### DIFF
--- a/android/src/main/java/com/cleverpush/reactnative/RNCleverPush.java
+++ b/android/src/main/java/com/cleverpush/reactnative/RNCleverPush.java
@@ -655,7 +655,7 @@ public class RNCleverPush extends ReactContextBaseJavaModule implements Lifecycl
     }
 
     /**
-     * Added for NativeEventEmitter
+     * Required for NativeEventEmitter
      */
     @ReactMethod
     public void addListener(String eventName) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,13 @@ declare module 'cleverpush-react-native' {
 	export default class CleverPush {
 		static init(channelId: string, options?: InitOptions): void;
 
+		// Event Listeners
+		static addSubscribedListener(listener: (event: SubscribedEvent) => void): EventSubscription;
+		static addNotificationOpenedListener(listener: (event: NotificationEvent) => void): EventSubscription;
+		static addNotificationReceivedListener(listener: (event: NotificationEvent) => void): EventSubscription;
+		static addAppBannerOpenedListener(listener: (event: AppBannerOpenedEvent) => void): EventSubscription;
+		static removeEventListener(subscription: EventSubscription): void;
+
 		static enableDevelopmentMode(): void;
 		static requestLocationPermission(): void;
 		static isSubscribed(callback: (error, isSubscribed: boolean) => void): void;
@@ -17,16 +24,6 @@ declare module 'cleverpush-react-native' {
 		static setBadgeCount(count: number): void;
 		static getBadgeCount(callback: (error, count: number) => void): void;
 		static clearNotificationsFromNotificationCenter(): void;
-
-		static addEventListener(
-			type: EventType,
-			handler: (result: { notification: Notification; subscription: Subscription }) => void
-		): void;
-		static removeEventListener(
-			type: EventType,
-			handler: (result: { notification: Notification; subscription: Subscription }) => void
-		): void;
-		static clearListeners(): void;
 
 		static getAvailableTags(callback: (error, channelTags: Tag[]) => void): void;
 		static getSubscriptionTags(callback: (error, tagIds: string[]) => void): void;
@@ -60,8 +57,6 @@ declare module 'cleverpush-react-native' {
 	export type InitOptions = {
 		autoRegister?: boolean;
 	};
-
-	type EventType = 'received' | 'opened' | 'subscribed' | 'appBannerOpened';
 
 	export interface Tag {
 		id: string;
@@ -139,5 +134,25 @@ declare module 'cleverpush-react-native' {
 
 	export interface NotificationCarouselItem {
 		mediaUrl: string;
+	}
+
+	export interface EventSubscription {
+		remove(): void;
+	}
+
+	export interface SubscribedEvent {
+		id: string;
+	}
+
+	export interface NotificationEvent {
+		notification: Notification;
+		subscription: Subscription;
+	}
+
+	export interface AppBannerOpenedEvent {
+		type: string;
+		name: string;
+		url: string;
+		urlType: string;
 	}
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,13 +2,6 @@ declare module 'cleverpush-react-native' {
 	export default class CleverPush {
 		static init(channelId: string, options?: InitOptions): void;
 
-		// Event Listeners
-		static addSubscribedListener(listener: (event: SubscribedEvent) => void): EventSubscription;
-		static addNotificationOpenedListener(listener: (event: NotificationEvent) => void): EventSubscription;
-		static addNotificationReceivedListener(listener: (event: NotificationEvent) => void): EventSubscription;
-		static addAppBannerOpenedListener(listener: (event: AppBannerOpenedEvent) => void): EventSubscription;
-		static removeEventListener(subscription: EventSubscription): void;
-
 		static enableDevelopmentMode(): void;
 		static requestLocationPermission(): void;
 		static isSubscribed(callback: (error, isSubscribed: boolean) => void): void;
@@ -24,6 +17,34 @@ declare module 'cleverpush-react-native' {
 		static setBadgeCount(count: number): void;
 		static getBadgeCount(callback: (error, count: number) => void): void;
 		static clearNotificationsFromNotificationCenter(): void;
+
+		static addEventListener(
+			type: 'received' | 'opened',
+			handler: (result: { notification: Notification; subscription: Subscription }) => void
+		): void;
+		static addEventListener(
+			type: 'subscribed',
+			handler: (result: { id: string }) => void
+		): void;
+		static addEventListener(
+			type: 'appBannerOpened',
+			handler: (result: { appBannerOpened: AppBannerOpenedEvent }) => void
+		): void;
+
+		static removeEventListener(
+			type: 'received' | 'opened',
+			handler: (result: { notification: Notification; subscription: Subscription }) => void
+		): void;
+		static removeEventListener(
+			type: 'subscribed',
+			handler: (result: { id: string }) => void
+		): void;
+		static removeEventListener(
+			type: 'appBannerOpened',
+			handler: (result: { appBannerOpened: AppBannerOpenedEvent }) => void
+		): void;
+
+		static clearListeners(): void;
 
 		static getAvailableTags(callback: (error, channelTags: Tag[]) => void): void;
 		static getSubscriptionTags(callback: (error, tagIds: string[]) => void): void;
@@ -57,6 +78,8 @@ declare module 'cleverpush-react-native' {
 	export type InitOptions = {
 		autoRegister?: boolean;
 	};
+
+	type EventType = 'received' | 'opened' | 'subscribed' | 'appBannerOpened';
 
 	export interface Tag {
 		id: string;
@@ -134,19 +157,6 @@ declare module 'cleverpush-react-native' {
 
 	export interface NotificationCarouselItem {
 		mediaUrl: string;
-	}
-
-	export interface EventSubscription {
-		remove(): void;
-	}
-
-	export interface SubscribedEvent {
-		id: string;
-	}
-
-	export interface NotificationEvent {
-		notification: Notification;
-		subscription: Subscription;
 	}
 
 	export interface AppBannerOpenedEvent {

--- a/index.js
+++ b/index.js
@@ -2,38 +2,90 @@ import { NativeModules, NativeEventEmitter, NetInfo, Platform } from 'react-nati
 import invariant from 'invariant';
 
 const RNCleverPush = NativeModules.CleverPush;
-const cleverPushEventEmitter = new NativeEventEmitter(RNCleverPush);
+
+const eventBroadcastNames = [
+  'CleverPush-notificationReceived',
+  'CleverPush-notificationOpened',
+  'CleverPush-appBannerOpened',
+  'CleverPush-subscribed'
+];
+
+var CleverPushEventEmitter;
+
+var _eventNames = ['received', 'opened', 'appBannerOpened', 'subscribed'];
+
+var _notificationHandler = new Map();
+var _notificationCache = new Map();
+var _listeners = [];
+
+if (RNCleverPush != null) {
+  CleverPushEventEmitter = new NativeEventEmitter(RNCleverPush);
+
+  for (var i = 0; i < eventBroadcastNames.length; i++) {
+    var eventBroadcastName = eventBroadcastNames[i];
+    var eventName = _eventNames[i];
+
+    _listeners[eventName] = handleEventBroadcast(eventName, eventBroadcastName)
+  }
+}
+
+function handleEventBroadcast(type, broadcast) {
+  return CleverPushEventEmitter.addListener(
+    broadcast, (notification) => {
+      var handler = _notificationHandler.get(type);
+
+      if (handler) {
+        handler(notification);
+      } else {
+        _notificationCache.set(type, notification);
+      }
+    }
+  );
+}
 
 function checkIfInitialized() {
   return RNCleverPush != null;
 }
 
 export default class CleverPush {
+  static addEventListener(type, handler) {
+    if (!checkIfInitialized()) return;
+
+    invariant(
+      type === 'received' || type === 'opened' || type === 'subscribed' || type === 'appBannerOpened',
+      'CleverPush only supports `received`, `opened`, `appBannerOpened`, and `subscribed` events'
+    );
+
+    _notificationHandler.set(type, handler);
+
+    var cache = _notificationCache.get(type);
+    if (handler && cache) {
+      handler(cache);
+      _notificationCache.delete(type);
+    }
+  }
+
+  static removeEventListener(type, handler) {
+    if (!checkIfInitialized()) return;
+
+    invariant(
+      type === 'received' || type === 'opened' || type === 'subscribed' || type === 'appBannerOpened',
+      'CleverPush only supports `received`, `opened`, `appBannerOpened`, and `subscribed` events'
+    );
+
+    _notificationHandler.delete(type);
+  }
+
+  static clearListeners() {
+    if (!checkIfInitialized()) return;
+
+    for (var i = 0; i < _eventNames.length; i++) {
+      _listeners[_eventNames].remove();
+    }
+  }
 
   static init(channelId, options) {
     RNCleverPush.init(Object.assign({ channelId }, options));
-  }
-
-  static addSubscribedListener(listener) {
-    return cleverPushEventEmitter.addListener('CleverPush-subscribed', listener);
-  }
-
-  static addNotificationOpenedListener(listener) {
-    return cleverPushEventEmitter.addListener('CleverPush-notificationOpened', listener);
-  }
-
-  static addNotificationReceivedListener(listener) {
-    return cleverPushEventEmitter.addListener('CleverPush-notificationReceived', listener);
-  }
-
-  static addAppBannerOpenedListener(listener) {
-    return cleverPushEventEmitter.addListener('CleverPush-appBannerOpened', listener);
-  }
-
-  static removeEventListener(subscription) {
-    if (subscription && typeof subscription.remove === 'function') {
-      subscription.remove();
-    }
   }
 
   static getAvailableTags(callback) {

--- a/ios/RCTCleverPush/RCTCleverPushEventEmitter.m
+++ b/ios/RCTCleverPush/RCTCleverPushEventEmitter.m
@@ -284,4 +284,13 @@ RCT_EXPORT_METHOD(disableAppBanners) {
         [CleverPush disableAppBanners];
 }
 
+// Required for RN built in Event Emitter Calls
+RCT_EXPORT_METHOD(addListener:(NSString *)eventName) {
+    // Keep: Required for RN built in Event Emitter Calls.
+}
+
+RCT_EXPORT_METHOD(removeListeners:(NSInteger)count) {
+    // Keep: Required for RN built in Event Emitter Calls.
+}
+
 @end

--- a/ios/RCTCleverPush/RCTCleverPushEventEmitter.m
+++ b/ios/RCTCleverPush/RCTCleverPushEventEmitter.m
@@ -284,7 +284,7 @@ RCT_EXPORT_METHOD(disableAppBanners) {
         [CleverPush disableAppBanners];
 }
 
-// Required for RN built in Event Emitter Calls
+// Required for NativeEventEmitter
 RCT_EXPORT_METHOD(addListener:(NSString *)eventName) {
     // Keep: Required for RN built in Event Emitter Calls.
 }


### PR DESCRIPTION
Subscribed Listener not working.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the issue where the subscribed listener was not called in the React Native SDK by updating event listener handling.

- **Bug Fixes**
  - Replaced the old event listener API with dedicated methods for each event type.
  - Updated TypeScript types and native iOS code to support the new listener structure.

<!-- End of auto-generated description by cubic. -->

