### PR TITLE
hotfix/cp-9692-rn-ios-sdk-notification-callback-is-not-called-sometimes

### DIFF
--- a/ios/RCTCleverPush/RCTCleverPushEventEmitter.m
+++ b/ios/RCTCleverPush/RCTCleverPushEventEmitter.m
@@ -284,13 +284,4 @@ RCT_EXPORT_METHOD(disableAppBanners) {
         [CleverPush disableAppBanners];
 }
 
-// Required for NativeEventEmitter
-RCT_EXPORT_METHOD(addListener:(NSString *)eventName) {
-    // Keep: Required for RN built in Event Emitter Calls.
-}
-
-RCT_EXPORT_METHOD(removeListeners:(NSInteger)count) {
-    // Keep: Required for RN built in Event Emitter Calls.
-}
-
 @end


### PR DESCRIPTION
Notification opened callback was not called sometimes.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an issue where the notification opened callback was not always triggered in the iOS SDK for React Native. Removed unused event listener methods to ensure reliable callback execution.

<!-- End of auto-generated description by cubic. -->

