### PR TITLE
hotfix/cp-11054-jcenter-not-supported-in-gradle-9

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,34 +1,23 @@
-buildscript {
-    repositories {
-        maven { url 'https://maven.google.com' }
-        mavenCentral()
-        jcenter()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0'
-    }
-}
-
-allprojects {
-    repositories {
-        maven { url 'https://maven.google.com' }
-        mavenCentral()
-        jcenter()
-    }
-}
-
 apply plugin: 'com.android.library'
 
 def safeExtGet(prop, fallback) {
-    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+    return rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
+repositories {
+    google()
+    mavenCentral()
 }
 
 android {
-    compileSdkVersion safeExtGet('compileSdkVersion', 33)
+    namespace "com.cleverpush.reactnative"
+
+    compileSdkVersion safeExtGet('compileSdkVersion', 34)
 
     defaultConfig {
-        minSdkVersion safeExtGet('minSdkVersion', 19)
+        minSdkVersion safeExtGet('minSdkVersion', 21)
     }
+
     buildTypes {
         release {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
@@ -38,6 +27,7 @@ android {
 
 dependencies {
     implementation fileTree(include: ['*.jar', '*.aar'], dir: 'libs')
+
     implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
 
     implementation('com.cleverpush:cleverpush:1.35.23') {


### PR DESCRIPTION
improve Gradle 8+ and Gradle 9 compatibility

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove `jcenter()` and modernize the Android Gradle config to work with Gradle 8 and 9. Addresses CP-11054 (jcenter not supported in Gradle 9) and meets AGP 8+ requirements.

- **Refactors**
  - Drop deprecated `buildscript`/`allprojects` blocks; add module `repositories { google(); mavenCentral() }`.
  - Add `namespace "com.cleverpush.reactnative"`.
  - Update `compileSdkVersion` to 34 and `minSdkVersion` to 21.
  - Make `safeExtGet` return explicit.

- **Migration**
  - Projects must target compile SDK 34 and min SDK 21 or higher.

<sup>Written for commit 2865ab37651ce6c27502742e587ec3f55cb5b533. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

